### PR TITLE
Fix: Move toolchain plugin configuration to central location

### DIFF
--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -11,12 +11,6 @@ repositories {
 allprojects {
   apply plugin: 'com.diffplug.spotless'
 
-  java {
-    toolchain {
-      languageVersion.set(JavaLanguageVersion.of(17))
-    }
-  }
-
   spotless {
     java {
       target 'src/**/*.java'

--- a/examples/java/buildSrc/src/main/groovy/uk.gov.api.common-conventions.gradle
+++ b/examples/java/buildSrc/src/main/groovy/uk.gov.api.common-conventions.gradle
@@ -13,6 +13,9 @@ version '0.1-SNAPSHOT'
 java {
   withSourcesJar()
   withJavadocJar()
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(17))
+  }
 }
 
 test {


### PR DESCRIPTION
It appears that this hasn't been working in the `allprojects` block, and
instead has only been working through luck.

We can move it into the common conventions so we can correctly use
toolchains, instead of leaving it up to the JDK we're executing under.
